### PR TITLE
Update build.sh with `cmake install`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,6 +24,7 @@ git submodule update --init --recursive
 brew install qt
 brew install autoconf 
 brew install automake 
+brew install cmake
 brew install libtool 
 brew install xz
 brew install pkg-config 


### PR DESCRIPTION
Some students had problems with missing cmake.
Adding cmake to brew install sequence to ensure it is present.
This should fix it (according to one of the student assistants)